### PR TITLE
refactor: Move apps to the same branch

### DIFF
--- a/basic_aggregator/main.py
+++ b/basic_aggregator/main.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from syftbox.lib import Client
+import os
+
+
+# Iterate over a list of participants, looking for their /public/value.txt
+# If they have the file, read it and aggregate in the total, otherwise, add the username in the missing list.
+# Return both total value and missing list.
+def aggregate(participants: list[str], datasite_path: Path):
+    result = 0
+    missing = []
+
+    for user_folder in participants:
+        value_file: Path = Path(datasite_path) / user_folder / "public" / "value.txt"
+
+        if value_file.exists():
+            with value_file.open("r") as file:
+                result += float(file.read())
+        else:
+            missing.append(user_folder)
+
+    return result, missing
+
+
+# Return a list of all network peers
+def network_participants(datasite_path: Path):
+    exclude_dir = ["apps", ".syft"]
+
+    entries = os.listdir(datasite_path)
+
+    users = []
+    for entry in entries:
+        if Path(datasite_path / entry).is_dir() and entry not in exclude_dir:
+            users.append(entry)
+
+    return users
+
+
+if __name__ == "__main__":
+    client = Client.load()
+
+    participants = network_participants(client.datasite_path.parent)
+
+    result, missing = aggregate(participants, client.datasite_path.parent)
+    print("\n====================\n")
+    print("Total aggregation value: ", result)
+    print("Missing value.txt peers: ", missing)
+    print("\n====================\n")
+
+    # Write the result to a public file
+    result_path = client.datasite_path / "public" / "result.txt"
+    with open(result_path, "w") as f:
+        f.write(str(result))

--- a/basic_aggregator/run.sh
+++ b/basic_aggregator/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# this will create venv from python version defined in .python-version
+uv venv
+
+uv pip install syftbox
+
+# run app using python from venv
+uv run main.py

--- a/dp_compute/main.py
+++ b/dp_compute/main.py
@@ -1,0 +1,64 @@
+from syftbox.lib import Client
+import os
+import sys
+import json
+import diffprivlib.tools as dp
+from pathlib import Path
+
+
+def compute_value(dataset):
+    return dp.mean(
+        dataset["data"],
+        epsilon=dataset["eps"],
+        bounds=tuple(dataset["bounds"]),
+    )
+
+
+def check_dataset_modified(dataset_path: Path):
+    checkpoint_path = dataset_path.with_suffix(".timestamp")
+    last_modified = os.stat(dataset_path).st_mtime
+
+    # if there is no checkpoint file,
+    # consider the dataset changed, since this is the first computation
+    if not checkpoint_path.is_file():
+        with open(checkpoint_path, "w") as f:
+            f.write(str(last_modified))
+        return True
+
+    with open(checkpoint_path) as f:
+        checkpoint = float(f.read())
+
+    if last_modified == checkpoint:
+        return False
+
+    with open(checkpoint_path, "w") as f:
+        f.write(str(last_modified))
+
+    return True
+
+
+if __name__ == "__main__":
+    client = Client.load()
+
+    dataset_path = client.datasite_path / "datasets" / "dataset.json"
+    value_path = client.datasite_path / "public" / "value.txt"
+
+    if not dataset_path.exists() or not dataset_path.is_file():
+        print("\n========== Compute ==========\n")
+        print(f"dataset not found at {dataset_path}. skipping computation...")
+        print("\n=============================\n")
+        sys.exit(0)
+
+    if not check_dataset_modified(dataset_path):
+        print("\n========== Compute ==========\n")
+        print(f"dataset didn't change. skipping computation...")
+        print("\n=============================\n")
+        sys.exit(0)
+
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+
+    value = compute_value(dataset)
+
+    with open(value_path, "w") as f:
+        f.write(str(value))

--- a/dp_compute/requirements.txt
+++ b/dp_compute/requirements.txt
@@ -1,0 +1,2 @@
+diffprivlib
+syftbox

--- a/dp_compute/run.sh
+++ b/dp_compute/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+uv venv
+
+uv pip install -r requirements.txt
+
+uv run main.py

--- a/model_aggregator/README.md
+++ b/model_aggregator/README.md
@@ -1,0 +1,13 @@
+# Model Aggregator App
+
+This app, together with the `model_local_training_app`, form a semi-FL app using SyftBox
+
+## Running in dev mode
+
+0. Clone the `model_local_training_app` and `model_aggregator` branches into the current directory
+1. Run 3 clients (`a, b, c`) with `just run-client a` and the SyftBox cache server `just run-server`
+2. Install the local training app on `b, c`: `syftbox app install model_local_training_app --config_path <path_to_config.json>` where `<path_to_config.json>` points to `b` or `c`'s `config.json` file
+3. Install the model aggregator app on `a`: `syftbox app install model_aggregator --config_path <path_to_config.json>` where `<path_to_config.json>` points to `a`'s `config.json` file
+4. Moving the MNIST data parts in `b` and `c`'s `private` into `private/datasets` to train
+5. The training logs can be seen at `b` and `c`'s `public/training.log`, and the trained model `.pt` will also be in the `public` folder once it's trained
+6. `a` will automatically aggregate the models from `b` and `c` when it detects if there are new trained model in `b` and `c`'s public folders. Check `a`'s SyftBox client log to see if the global model accuracy has improved. Look for key words "Aggregating models between" and "Global model accuracy"

--- a/model_aggregator/main.py
+++ b/model_aggregator/main.py
@@ -1,0 +1,175 @@
+from pathlib import Path
+from syftbox.lib import Client
+import os
+from datetime import datetime, timedelta
+import json
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class SimpleNN(nn.Module):
+    def __init__(self):
+        super(SimpleNN, self).__init__()
+        self.fc1 = nn.Linear(28 * 28, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = x.view(-1, 28 * 28)
+        x = torch.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+def aggregate_model(
+    participants: list[str], datasite_path: Path, global_model_path: Path
+):
+    global_model = SimpleNN()
+    global_model_state_dict = global_model.state_dict()
+
+    aggregated_model_weights = {}
+
+    n_peers = len(participants)
+    for user_folder in participants:
+        model_file: Path = Path(datasite_path) / user_folder / "public" / "model.pth"
+
+        user_model_state = torch.load(str(model_file))
+        for key in global_model_state_dict.keys():
+
+            # If user model has a different architecture than my global model.
+            # Skip it
+            if user_model_state.keys() != global_model_state_dict.keys():
+                continue
+
+            if aggregated_model_weights.get(key, None) is None:
+                aggregated_model_weights[key] = user_model_state[key] * (1 / n_peers)
+            else:
+                aggregated_model_weights[key] += user_model_state[key] * (1 / n_peers)
+
+    if aggregated_model_weights:
+        global_model.load_state_dict(aggregated_model_weights)
+        torch.save(global_model.state_dict(), str(global_model_path))
+        return global_model
+    else:
+        return None
+
+
+def peer_has_new_model(dataset_peer_path: Path) -> bool:
+    model_path: Path = Path(dataset_peer_path / "public" / "model.pth")
+    last_model_update: Path = Path(dataset_peer_path / "public" / "model_training.json")
+
+    if model_path.is_file() and last_model_update.is_file():
+        with open(str(last_model_update), "r") as model_info:
+            model_info = json.load(model_info)
+
+        last_trained_time = datetime.fromisoformat(model_info["last_train"])
+        time_now = datetime.now()
+
+        if (time_now - last_trained_time) <= timedelta(minutes=10):
+            return True
+
+    return False
+
+
+def network_participants(datasite_path: Path):
+    exclude_dir = ["apps", ".syft"]
+
+    entries = os.listdir(datasite_path)
+
+    users = []
+    for entry in entries:
+        user_path = Path(datasite_path / entry)
+        is_excluded_dir = entry in exclude_dir
+
+        is_valid_peer = user_path.is_dir() and not is_excluded_dir
+        if is_valid_peer and peer_has_new_model(user_path):
+            users.append(entry)
+
+    return users
+
+
+def time_to_aggregate(datasite_path: Path):
+    last_round_file_path: Path = (
+        Path(datasite_path) / "app_pipelines" / "fl_app" / "last_round.json"
+    )
+    fl_pipeline_path: Path = last_round_file_path.parent
+
+    if not fl_pipeline_path.is_dir():
+        os.makedirs(str(fl_pipeline_path))
+        return True
+
+    with open(str(last_round_file_path), "r") as last_round_file:
+        last_round_info = json.load(last_round_file)
+
+        last_trained_time = datetime.fromisoformat(last_round_info["last_train"])
+        time_now = datetime.now()
+
+        if (time_now - last_trained_time) >= timedelta(seconds=10):
+            return True
+
+    return False
+
+
+def save_aggregation_timestamp(datasite_path: Path) -> None:
+    last_round_file_path: Path = (
+        Path(datasite_path) / "app_pipelines" / "fl_app" / "last_round.json"
+    )
+    with open(str(last_round_file_path), "w") as last_round_file:
+        timestamp = datetime.now().isoformat()
+        json.dump({"last_train": timestamp}, last_round_file)
+
+
+def evaluate_global_model(global_model: nn.Module, dataset_path: Path) -> float:
+    global_model.eval()
+
+    # load the saved mnist subset
+    images, labels = torch.load(str(dataset_path))
+
+    # create a tensordataset
+    dataset = TensorDataset(images, labels)
+
+    # create a dataloader for the dataset
+    data_loader = DataLoader(dataset, batch_size=64, shuffle=True)
+
+    # dataset = torch.load(str(dataset_path))
+    # data_loader = torch.utils.data.DataLoader(dataset, batch_size=64, shuffle=False)
+
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in data_loader:
+            outputs = global_model(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    accuracy = 100 * correct / total
+    return accuracy
+
+
+if __name__ == "__main__":
+    client = Client.load()
+
+    if not time_to_aggregate(client.datasite_path):
+        print("It's not time for a new aggregation round,  skipping it for now.")
+        exit()
+
+    participants = network_participants(client.datasite_path.parent)
+
+    global_model = None
+    if len(participants) == 0:
+        print("No new model found! Skipping aggregation...")
+    else:
+        print("Aggregating models between ", participants)
+
+        global_model = aggregate_model(
+            participants,
+            client.datasite_path.parent,
+            client.datasite_path / "public" / "global_model.pth",
+        )
+
+    if global_model:
+        dataset_path = "./mnist_dataset.pt"
+        accuracy = evaluate_global_model(global_model, dataset_path)
+        print(f"Global model accuracy: {accuracy:.2f}%")
+
+    save_aggregation_timestamp(client.datasite_path)

--- a/model_aggregator/run.sh
+++ b/model_aggregator/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# this will create venv from python version defined in .python-version
+uv venv
+
+uv pip install torch syftbox
+
+# run app using python from venv
+uv run main.py

--- a/model_local_training/README.md
+++ b/model_local_training/README.md
@@ -1,0 +1,13 @@
+# Model Local Training App
+
+This app, together with the `model_aggregator` app, form a semi-FL app using SyftBox
+
+## Running in dev mode
+
+0. Clone the `model_local_training_app` and `model_aggregator` branches into the current directory
+1. Run 3 clients (`a, b, c`) with `just run-client a` and the SyftBox cache server `just run-server`
+2. Install the local training app on `b, c`: `syftbox app install model_local_training_app --config_path <path_to_config.json>` where `<path_to_config.json>` points to `b` or `c`'s `config.json` file
+3. Install the model aggregator app on `a`: `syftbox app install model_aggregator --config_path <path_to_config.json>` where `<path_to_config.json>` points to `a`'s `config.json` file
+4. Moving the MNIST data parts in `b` and `c`'s `private` into `private/datasets` to train
+5. The training logs can be seen at `b` and `c`'s `public/training.log`, and the trained model `.pt` will also be in the `public` folder once it's trained
+6. `a` will automatically aggregate the models from `b` and `c` when it detects if there are new trained model in `b` and `c`'s public folders. Check `a`'s SyftBox client log to see if the global model accuracy has improved. Look for key words "Aggregating models between" and "Global model accuracy"

--- a/model_local_training/main.py
+++ b/model_local_training/main.py
@@ -1,0 +1,160 @@
+import torch
+import torch.nn as nn
+from datetime import datetime, timedelta
+from syftbox.lib import Client
+from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
+import os
+from pathlib import Path
+import torch.optim as optim
+import json
+import shutil
+
+
+class SimpleNN(nn.Module):
+    def __init__(self):
+        super(SimpleNN, self).__init__()
+        self.fc1 = nn.Linear(28 * 28, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = x.view(-1, 28 * 28)
+        x = torch.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+def look_for_datasets(dataset_path: Path):
+    if not dataset_path.is_dir():
+        os.makedirs(str(dataset_path))
+
+    dataset_path_files = [f for f in os.listdir(str(dataset_path)) if f.endswith(".pt")]
+    return dataset_path_files
+
+
+def train_model(datasite_path: Path, dataset_path: Path, public_folder_path: Path):
+    dataset_path_files = look_for_datasets(dataset_path=dataset_path)
+
+    if len(dataset_path_files) == 0:
+        print(f"No dataset found in {dataset_path} skipping training.")
+        return
+
+    model = SimpleNN()  # Initialize train_model
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+
+    all_datasets = []
+    for dataset_file in dataset_path_files:
+
+        # load the saved mnist subset
+        images, labels = torch.load(str(dataset_path) + "/" + dataset_file)
+
+        # create a tensordataset
+        dataset = TensorDataset(images, labels)
+
+        all_datasets.append(dataset)
+
+    combined_dataset = ConcatDataset(all_datasets)
+
+    # create a dataloader for the dataset
+    train_loader = DataLoader(combined_dataset, batch_size=64, shuffle=True)
+
+    # Open log file in append mode
+    output_logs_path = Path(public_folder_path / "training.log")
+    log_file = open(str(output_logs_path), "a")
+
+    # Log training start
+    start_msg = f"[{datetime.now().isoformat()}] Starting training...\n"
+    log_file.write(start_msg)
+    log_file.flush()
+
+    # training loop
+    for epoch in range(1000):
+        running_loss = 0
+        for images, labels in train_loader:
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # accumulate loss
+            running_loss += loss.item()
+
+        # Calculate average loss for the epoch
+        avg_loss = running_loss / len(train_loader)
+        log_msg = f"[{datetime.now().isoformat()}] Epoch {epoch + 1:04d}: Loss = {avg_loss:.6f}\n"
+        log_file.write(log_msg)
+        log_file.flush()  # Force write to disk
+
+    # Serialize the model
+    output_model_path = Path(public_folder_path / "model.pth")
+    torch.save(model.state_dict(), str(output_model_path))
+
+    output_training_json_path = Path(public_folder_path / "model_training.json")
+    with open(str(output_training_json_path), "w") as training_info_file:
+        timestamp = datetime.now().isoformat()
+        json.dump({"last_train": timestamp}, training_info_file)
+
+    # Log completion
+    final_msg = f"[{datetime.now().isoformat()}] Training completed. Final loss: {avg_loss:.6f}\n"
+    log_file.write(final_msg)
+    log_file.flush()
+    log_file.close()
+
+
+def time_to_train(datasite_path: Path):
+    last_round_file_path: Path = (
+        Path(datasite_path) / "app_pipelines" / "fl_app" / "last_round.json"
+    )
+    fl_pipeline_path: Path = last_round_file_path.parent
+
+    if not fl_pipeline_path.is_dir():
+        os.makedirs(str(fl_pipeline_path))
+        copy_folder_contents("./mnist_samples", str(datasite_path / "private/"))
+        return True
+
+    with open(str(last_round_file_path), "r") as last_round_file:
+        last_round_info = json.load(last_round_file)
+
+        last_trained_time = datetime.fromisoformat(last_round_info["last_train"])
+        time_now = datetime.now()
+
+        if (time_now - last_trained_time) >= timedelta(seconds=10):
+            return True
+
+    return False
+
+
+def save_training_timestamp(datasite_path: Path) -> None:
+    last_round_file_path: Path = (
+        Path(datasite_path) / "app_pipelines" / "fl_app" / "last_round.json"
+    )
+    with open(str(last_round_file_path), "w") as last_round_file:
+        timestamp = datetime.now().isoformat()
+        json.dump({"last_train": timestamp}, last_round_file)
+
+
+def copy_folder_contents(src_folder, dest_folder):
+    if not os.path.exists(dest_folder):
+        os.makedirs(dest_folder)
+    for item in os.listdir(src_folder):
+        src_path = os.path.join(src_folder, item)
+        dest_path = os.path.join(dest_folder, item)
+        if not os.path.isdir(src_path):
+            shutil.copy2(src_path, dest_path)
+
+
+if __name__ == "__main__":
+    client = Client.load()
+    if not time_to_train(client.datasite_path):
+        print("It's not time for a new training routine. skipping it for now.")
+        exit()
+
+    dataset_path = Path(client.datasite_path / "private" / "datasets")
+    public_folder = Path(client.datasite_path / "public")
+    output_model_path = Path(public_folder / "model.pth")
+    output_model_info = Path(public_folder / "model_training.json")
+    os.makedirs(dataset_path, exist_ok=True)
+    train_model(client.datasite_path, dataset_path, public_folder)
+    save_training_timestamp(client.datasite_path)

--- a/model_local_training/run.sh
+++ b/model_local_training/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# this will create venv from python version defined in .python-version
+uv venv
+
+uv pip install torch syftbox
+
+# run app using python from venv
+uv run main.py

--- a/pretrained_model_aggregator/README.md
+++ b/pretrained_model_aggregator/README.md
@@ -1,0 +1,21 @@
+# Pretrained Model Aggregator App
+
+This app, together with the `pretrained_model_local` app, form an aggregation pipeline for pretrained MNIST models using SyftBox
+
+## Running in dev mode
+
+0. Reset everything if necessary with `just reset`. Clone the `pretrained_model_local` and `pretrained_model_aggregator` branches into the current directory, e.g. with the command `git clone --branch pretrained_model_aggregator https://github.com/OpenMined/tutorial-apps.git pretrained_model_aggregator`
+1. Run upto 11 clients (`a, b, c...`) with `just run-client <client_name>` and the SyftBox cache server `just run-server`. Here, `a` will be the model aggregator
+2. Install the local pretrained app on `b, c, ...`: `syftbox app install pretrained_model_local --config_path <path_to_config.json>` where `<path_to_config.json>` points to `b` or `c` or other clients' `config.json` file
+3. Install the model aggregator app on `a`: `syftbox app install pretrained_model_aggregator --config_path <path_to_config.json>` where `<path_to_config.json>` points to `a`'s `config.json` file
+4. In `a`'s `apps/pretrained_model_aggregator` folder, modify the participants in `participants.json`
+5. Move the participants' MNIST pretrained model in their `private` folder into `public` to let it be aggregated by `a`
+6. `a` will automatically look for and aggregate the models from other clients. Check `a`'s SyftBox client log to see if the global model accuracy has improved, look for key words "Aggregated models from" and "Global model accuracy"
+
+## Running live as a model aggregator
+
+0. Clone the `pretrained_model_aggregator` branch into the current directory, e.g. with the command `git clone --branch pretrained_model_aggregator https://github.com/OpenMined/tutorial-apps.git pretrained_model_aggregator`
+1. Run your syft client with `syftbox client`
+2. Install the aggregator app `syftbox app install pretrained_model_aggregator`
+3. Go to your sync folder's `apps/pretrained_model_aggregator` and change the list of participants in `participants.json`
+4. Wait for the participants to submit their pretrained models. Monitor your syftbox client logs, look for key words "Aggregated models from" and "Global model accuracy"

--- a/pretrained_model_aggregator/main.py
+++ b/pretrained_model_aggregator/main.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+from syftbox.lib import Client
+import os
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+import re
+import json
+
+
+class SimpleNN(nn.Module):
+    def __init__(self):
+        super(SimpleNN, self).__init__()
+        self.fc1 = nn.Linear(28 * 28, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = x.view(-1, 28 * 28)
+        x = torch.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+def get_model_file(path: Path) -> str | None:
+    model_files = []
+    entries = os.listdir(path)
+    pattern = r"^pretrained_mnist_label_[0-9]\.pt$"
+
+    for entry in entries:
+        if re.match(pattern, entry):
+            model_files.append(entry)
+
+    return model_files[0] if model_files else None
+
+
+def aggregate_model(
+    participants: list[str], datasite_path: Path, global_model_path: Path
+):
+    global_model = SimpleNN()
+    global_model_state_dict = global_model.state_dict()
+
+    aggregated_model_weights = {}
+
+    n_peers = len(participants)
+    aggregated_peers = []
+    for user_folder in participants:
+        public_folder_path: Path = Path(datasite_path) / user_folder / "public"
+
+        model_file = get_model_file(public_folder_path)
+        if model_file is None:
+            continue
+        model_file = public_folder_path / model_file
+        aggregated_peers.append(user_folder)
+
+        user_model_state = torch.load(str(model_file))
+        for key in global_model_state_dict.keys():
+
+            # If user model has a different architecture than my global model.
+            # Skip it
+            if user_model_state.keys() != global_model_state_dict.keys():
+                continue
+
+            if aggregated_model_weights.get(key, None) is None:
+                aggregated_model_weights[key] = user_model_state[key] * (1 / n_peers)
+            else:
+                aggregated_model_weights[key] += user_model_state[key] * (1 / n_peers)
+
+    if aggregated_model_weights:
+        print(f"Aggregated models from {aggregated_peers}")
+        global_model.load_state_dict(aggregated_model_weights)
+        torch.save(global_model.state_dict(), str(global_model_path))
+        return global_model
+    else:
+        return None
+
+
+def network_participants(datasite_path: Path, participants_json_file_path: Path):
+    exclude_dir = ["apps", ".syft"]
+    entries = os.listdir(datasite_path)
+    with open(participants_json_file_path, "r") as f:
+        participants = json.load(f)
+        participants = participants["participants"]
+
+    all_users = []
+    for entry in entries:
+        user_path = Path(datasite_path / entry)
+        is_excluded_dir = entry in exclude_dir
+        is_valid_peer = user_path.is_dir() and not is_excluded_dir
+        if is_valid_peer:
+            all_users.append(entry)
+
+    participants = list(set(participants) & set(all_users))
+    missing_participants = list(set(participants) - set(all_users))
+    print(f"Pretrained model aggregator participants: {participants}")
+    return participants
+
+
+def evaluate_global_model(global_model: nn.Module, dataset_path: Path) -> float:
+    global_model.eval()
+    # load the saved mnist subset
+    images, labels = torch.load(str(dataset_path))
+    # create a tensordataset
+    dataset = TensorDataset(images, labels)
+    # create a dataloader for the dataset
+    data_loader = DataLoader(dataset, batch_size=64, shuffle=True)
+    # dataset = torch.load(str(dataset_path))
+    # data_loader = torch.utils.data.DataLoader(dataset, batch_size=64, shuffle=False)
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in data_loader:
+            outputs = global_model(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    accuracy = 100 * correct / total
+    return accuracy
+
+
+if __name__ == "__main__":
+    client = Client.load()
+    participants = network_participants(
+        client.datasite_path.parent, Path("participants.json")
+    )
+    global_model = None
+    global_model = aggregate_model(
+        participants,
+        client.datasite_path.parent,
+        client.datasite_path / "public" / "global_model.pth",
+    )
+    if global_model:
+        dataset_path = "./mnist_dataset.pt"
+        accuracy = evaluate_global_model(global_model, dataset_path)
+        print(f"Global model accuracy: {accuracy:.2f}%")
+    else:
+        print("No models to aggregate")

--- a/pretrained_model_aggregator/participants.json
+++ b/pretrained_model_aggregator/participants.json
@@ -1,0 +1,3 @@
+{
+  "participants": ["khoa2@openmined.org", "khoa3@openmined.org"]
+}

--- a/pretrained_model_aggregator/run.sh
+++ b/pretrained_model_aggregator/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# this will create venv from python version defined in .python-version
+uv venv
+
+uv pip install --upgrade torch syftbox
+# run app using python from venv
+uv run main.py

--- a/pretrained_model_local/README.md
+++ b/pretrained_model_local/README.md
@@ -1,0 +1,20 @@
+# Model Aggregator App
+
+This app, together with the `pretrained_model_aggregator` app, form an aggregation pipeline for pretrained MNIST models using SyftBox
+
+## Running in dev mode
+
+0. Reset everything if necessary with `just reset`. Clone the `pretrained_model_local` and `pretrained_model_aggregator` branches into the current directory, e.g. with the command `git clone --branch pretrained_model_local https://github.com/OpenMined/tutorial-apps.git pretrained_model_local`
+1. Run upto 11 clients (`a, b, c...`) with `just run-client <client_name>` and the SyftBox cache server `just run-server`. Here, `a` will be the model aggregator
+2. Install the local pretrained app on `b, c, ...`: `syftbox app install pretrained_model_local --config_path <path_to_config.json>` where `<path_to_config.json>` points to `b` or `c` or other clients' `config.json` file
+3. Install the model aggregator app on `a`: `syftbox app install pretrained_model_aggregator --config_path <path_to_config.json>` where `<path_to_config.json>` points to `a`'s `config.json` file
+4. Move the MNIST pretrained model in `b`, `c`, or other clients' `private` folder into `public` to let it be aggregated by `a`
+5. `a` will automatically look for and aggregate the models from other clients. Check `a`'s SyftBox client log to see if the global model accuracy has improved, look for key words "Aggregated models from" and "Global model accuracy"
+
+## Running live as a model submitter
+
+0. Clone the `pretrained_model_local` branch into the current directory, e.g. with the command `git clone --branch pretrained_model_local https://github.com/OpenMined/tutorial-apps.git pretrained_model_local`
+1. Run your syft client with `syftbox client`
+2. Install the app with `syftbox app install pretrained_model_local`
+3. Go to your sync folder's datasite, you will see that you have a pretrained MNIST model in your `private/` folder, e.g. `pretrained_mnist_label_2.pt`
+4. Submit your model for aggregation by copying / dragging the pretrained model from the `private/` folder into the `public/` folder. Note that the model aggregator needs to list you as a participant for your model to be aggregated

--- a/pretrained_model_local/main.py
+++ b/pretrained_model_local/main.py
@@ -1,0 +1,39 @@
+from syftbox.lib import Client
+import random
+import os
+from pathlib import Path
+import shutil
+import re
+
+
+def copy_random_pretrained_model(path: Path):
+    pattern = "pretrained_mnist_label_[0-9]\.pt$"
+    # check if there is any pretrained model in the path
+    pretrained_entries = os.listdir(path)
+    pretrained_model_exists = any(
+        [re.match(pattern, entry) for entry in pretrained_entries]
+    )
+    if pretrained_model_exists:
+        return
+
+    pretrained_model_path = Path("./") / "pretrained_models"
+    entries = os.listdir(pretrained_model_path)
+    # generate random number from the number of entries
+    random_index = random.randint(0, len(entries) - 1)
+    # get the random entry
+    random_entry = entries[random_index]
+
+    print("Copying Pretrained Model: ", random_entry)
+    # copy the random entry to the path
+    shutil.copy2(pretrained_model_path / random_entry, path)
+
+
+if __name__ == "__main__":
+    client = Client.load()
+
+    # Create Private Directory
+    private_path = Path(client.datasite_path) / "private"
+    os.makedirs(private_path, exist_ok=True)
+
+    # Copy a Randon Pretrained Model to private
+    copy_random_pretrained_model(private_path)

--- a/pretrained_model_local/run.sh
+++ b/pretrained_model_local/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# this will create venv from python version defined in .python-version
+uv venv
+
+uv pip install torch syftbox
+
+# run app using python from venv
+uv run main.py

--- a/pretrained_model_local/train.ipynb
+++ b/pretrained_model_local/train.ipynb
@@ -1,0 +1,342 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn, optim\n",
+    "from torch.utils.data import DataLoader, TensorDataset\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SimpleNN(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(SimpleNN, self).__init__()\n",
+    "        self.fc1 = nn.Linear(28 * 28, 128)\n",
+    "        self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = x.view(-1, 28 * 28)\n",
+    "        x = torch.relu(self.fc1(x))\n",
+    "        x = self.fc2(x)\n",
+    "        return x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('mnist_samples/mnist_label_0.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_1.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_2.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_3.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_4.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_5.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_6.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_7.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_8.pt'),\n",
+       " PosixPath('mnist_samples/mnist_label_9.pt')]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_path = Path(\"mnist_samples\")\n",
+    "dataset_path_files = sorted(list(dataset_path.glob(\"*.pt\")))\n",
+    "dataset_path_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('pretrained_models/pretrained_mnist_label_0.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_1.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_2.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_3.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_4.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_5.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_6.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_7.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_8.pt'),\n",
+       " PosixPath('pretrained_models/pretrained_mnist_label_9.pt')]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "saved_models = [Path('pretrained_models') / ('pretrained_' + f.name) for f in dataset_path_files]\n",
+    "saved_models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_model(dataset_file_path: Path, saved_model_path: Path):\n",
+    "\n",
+    "    model = SimpleNN()  # Initialize train_model\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = optim.SGD(model.parameters(), lr=0.1)\n",
+    "\n",
+    "    images, labels = torch.load(dataset_file_path)\n",
+    "\n",
+    "    # create a tensordataset\n",
+    "    dataset = TensorDataset(images, labels)\n",
+    "\n",
+    "    # create a dataloader for the dataset\n",
+    "    train_loader = DataLoader(dataset, batch_size=64, shuffle=True)\n",
+    "\n",
+    "    # training loop\n",
+    "    for epoch in range(1000):\n",
+    "        running_loss = 0\n",
+    "        for images, labels in train_loader:\n",
+    "            optimizer.zero_grad()\n",
+    "            outputs = model(images)\n",
+    "            loss = criterion(outputs, labels)\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "\n",
+    "            # accumulate loss\n",
+    "            running_loss += loss.item()\n",
+    "        \n",
+    "        # Calculate average loss for the epoch\n",
+    "        avg_loss = running_loss / len(train_loader)\n",
+    "\n",
+    "        if (epoch + 1) % 100 == 0:\n",
+    "            avg_loss = running_loss / len(train_loader)\n",
+    "            print(f\"Epoch {epoch + 1:04d}: Loss = {avg_loss:.6f}\")\n",
+    "\n",
+    "    # Save the model\n",
+    "    torch.save(model.state_dict(), str(saved_model_path))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_2148638/1992216445.py:7: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n",
+      "  images, labels = torch.load(dataset_file_path)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0100: Loss = 0.000087\n",
+      "Epoch 0200: Loss = 0.000047\n",
+      "Epoch 0300: Loss = 0.000026\n",
+      "Epoch 0400: Loss = 0.000020\n",
+      "Epoch 0500: Loss = 0.000015\n",
+      "Epoch 0600: Loss = 0.000012\n",
+      "Epoch 0700: Loss = 0.000011\n",
+      "Epoch 0800: Loss = 0.000009\n",
+      "Epoch 0900: Loss = 0.000008\n",
+      "Epoch 1000: Loss = 0.000007\n",
+      "Epoch 0100: Loss = 0.000117\n",
+      "Epoch 0200: Loss = 0.000058\n",
+      "Epoch 0300: Loss = 0.000035\n",
+      "Epoch 0400: Loss = 0.000026\n",
+      "Epoch 0500: Loss = 0.000020\n",
+      "Epoch 0600: Loss = 0.000017\n",
+      "Epoch 0700: Loss = 0.000015\n",
+      "Epoch 0800: Loss = 0.000013\n",
+      "Epoch 0900: Loss = 0.000011\n",
+      "Epoch 1000: Loss = 0.000010\n",
+      "Epoch 0100: Loss = 0.000098\n",
+      "Epoch 0200: Loss = 0.000046\n",
+      "Epoch 0300: Loss = 0.000030\n",
+      "Epoch 0400: Loss = 0.000021\n",
+      "Epoch 0500: Loss = 0.000017\n",
+      "Epoch 0600: Loss = 0.000014\n",
+      "Epoch 0700: Loss = 0.000012\n",
+      "Epoch 0800: Loss = 0.000010\n",
+      "Epoch 0900: Loss = 0.000009\n",
+      "Epoch 1000: Loss = 0.000008\n",
+      "Epoch 0100: Loss = 0.000090\n",
+      "Epoch 0200: Loss = 0.000042\n",
+      "Epoch 0300: Loss = 0.000027\n",
+      "Epoch 0400: Loss = 0.000020\n",
+      "Epoch 0500: Loss = 0.000016\n",
+      "Epoch 0600: Loss = 0.000013\n",
+      "Epoch 0700: Loss = 0.000011\n",
+      "Epoch 0800: Loss = 0.000010\n",
+      "Epoch 0900: Loss = 0.000008\n",
+      "Epoch 1000: Loss = 0.000008\n",
+      "Epoch 0100: Loss = 0.000099\n",
+      "Epoch 0200: Loss = 0.000047\n",
+      "Epoch 0300: Loss = 0.000030\n",
+      "Epoch 0400: Loss = 0.000022\n",
+      "Epoch 0500: Loss = 0.000018\n",
+      "Epoch 0600: Loss = 0.000014\n",
+      "Epoch 0700: Loss = 0.000012\n",
+      "Epoch 0800: Loss = 0.000010\n",
+      "Epoch 0900: Loss = 0.000009\n",
+      "Epoch 1000: Loss = 0.000008\n",
+      "Epoch 0100: Loss = 0.000107\n",
+      "Epoch 0200: Loss = 0.000052\n",
+      "Epoch 0300: Loss = 0.000033\n",
+      "Epoch 0400: Loss = 0.000024\n",
+      "Epoch 0500: Loss = 0.000019\n",
+      "Epoch 0600: Loss = 0.000016\n",
+      "Epoch 0700: Loss = 0.000013\n",
+      "Epoch 0800: Loss = 0.000011\n",
+      "Epoch 0900: Loss = 0.000010\n",
+      "Epoch 1000: Loss = 0.000009\n",
+      "Epoch 0100: Loss = 0.000098\n",
+      "Epoch 0200: Loss = 0.000046\n",
+      "Epoch 0300: Loss = 0.000031\n",
+      "Epoch 0400: Loss = 0.000023\n",
+      "Epoch 0500: Loss = 0.000017\n",
+      "Epoch 0600: Loss = 0.000014\n",
+      "Epoch 0700: Loss = 0.000012\n",
+      "Epoch 0800: Loss = 0.000010\n",
+      "Epoch 0900: Loss = 0.000010\n",
+      "Epoch 1000: Loss = 0.000008\n",
+      "Epoch 0100: Loss = 0.000125\n",
+      "Epoch 0200: Loss = 0.000057\n",
+      "Epoch 0300: Loss = 0.000036\n",
+      "Epoch 0400: Loss = 0.000027\n",
+      "Epoch 0500: Loss = 0.000021\n",
+      "Epoch 0600: Loss = 0.000017\n",
+      "Epoch 0700: Loss = 0.000014\n",
+      "Epoch 0800: Loss = 0.000013\n",
+      "Epoch 0900: Loss = 0.000011\n",
+      "Epoch 1000: Loss = 0.000010\n",
+      "Epoch 0100: Loss = 0.000094\n",
+      "Epoch 0200: Loss = 0.000046\n",
+      "Epoch 0300: Loss = 0.000030\n",
+      "Epoch 0400: Loss = 0.000026\n",
+      "Epoch 0500: Loss = 0.000017\n",
+      "Epoch 0600: Loss = 0.000014\n",
+      "Epoch 0700: Loss = 0.000012\n",
+      "Epoch 0800: Loss = 0.000011\n",
+      "Epoch 0900: Loss = 0.000010\n",
+      "Epoch 1000: Loss = 0.000008\n",
+      "Epoch 0100: Loss = 0.000096\n",
+      "Epoch 0200: Loss = 0.000045\n",
+      "Epoch 0300: Loss = 0.000029\n",
+      "Epoch 0400: Loss = 0.000021\n",
+      "Epoch 0500: Loss = 0.000018\n",
+      "Epoch 0600: Loss = 0.000014\n",
+      "Epoch 0700: Loss = 0.000012\n",
+      "Epoch 0800: Loss = 0.000010\n",
+      "Epoch 0900: Loss = 0.000009\n",
+      "Epoch 1000: Loss = 0.000008\n"
+     ]
+    }
+   ],
+   "source": [
+    "for dataset_file_path, saved_model_path in zip(dataset_path_files, saved_models):\n",
+    "    train_model(dataset_file_path, saved_model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_model(model_path: Path, test_data_path: Path):\n",
+    "    # Load the model\n",
+    "    model = SimpleNN()\n",
+    "    model.load_state_dict(torch.load(str(model_path), weights_only=True))\n",
+    "    model.eval()\n",
+    "    \n",
+    "    # Load test data\n",
+    "    test_images, test_labels = torch.load(test_data_path, weights_only=True)\n",
+    "    \n",
+    "    # Make predictions\n",
+    "    with torch.no_grad():\n",
+    "        outputs = model(test_images)\n",
+    "        _, predicted = torch.max(outputs.data, 1)\n",
+    "    \n",
+    "    # Calculate accuracy\n",
+    "    total = test_labels.size(0)\n",
+    "    correct = (predicted == test_labels).sum().item()\n",
+    "    accuracy = 100 * correct / total\n",
+    "    \n",
+    "    print(f'Accuracy on test data: {accuracy:.2f}%')\n",
+    "    return accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n",
+      "Accuracy on test data: 100.00%\n"
+     ]
+    }
+   ],
+   "source": [
+    "for model_path, test_data_path in zip(saved_models, dataset_path_files):\n",
+    "    test_model(model_path, test_data_path)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Moved apps from separate branches to the same branch (`main`).

The main reasons for this PR:
- switching between multiple branches becomes cumbersome if working on multiple apps
- helps making sure apps are consistent (same `run.sh` format etc.)
- `syftbox app install` creates a symlink, so switching branches in this repo will directly affect what app runs on a user's client; technically, cloning branches from this repo in separate directories helps avoid this, but it's more unintuitive than having all the apps in the same directory
